### PR TITLE
Upgrade MiniMax default model to M3

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ DeepGit supports multiple LLM providers. Set the `LLM_PROVIDER` environment vari
 | Provider | Env Var | Default Model | Notes |
 |----------|---------|---------------|-------|
 | **Groq** (default) | `GROQ_API_KEY` | `deepseek-r1-distill-llama-70b` | Free tier available |
-| **[MiniMax](https://www.minimaxi.com)** | `MINIMAX_API_KEY` | `MiniMax-M2.7` | 204K context, OpenAI-compatible |
+| **[MiniMax](https://www.minimaxi.com)** | `MINIMAX_API_KEY` | `MiniMax-M3` | 512K context, OpenAI-compatible |
 
 ```bash
 # Option A: Groq (default — no extra config needed)
@@ -140,7 +140,7 @@ GROQ_API_KEY=your_groq_api_key
 # Option B: MiniMax
 LLM_PROVIDER=minimax
 MINIMAX_API_KEY=your_minimax_api_key
-# LLM_MODEL=MiniMax-M2.7          # optional: override default model
+# LLM_MODEL=MiniMax-M3            # optional: override default model
 ```
 
 > **Tip:** If `LLM_PROVIDER` is not set, DeepGit auto-detects the provider from available API keys.

--- a/tests/test_llm_provider.py
+++ b/tests/test_llm_provider.py
@@ -110,7 +110,7 @@ class TestCreateLLMMiniMax:
                 llm = mod.create_llm(temperature=0.3, max_tokens=512)
                 mock_cls.assert_called_once()
                 call_kwargs = mock_cls.call_args[1]
-                assert call_kwargs["model"] == "MiniMax-M2.7"
+                assert call_kwargs["model"] == "MiniMax-M3"
                 assert call_kwargs["base_url"] == "https://api.minimax.io/v1"
                 assert call_kwargs["api_key"] == "test-key-abc"
                 assert call_kwargs["temperature"] == 0.3
@@ -163,7 +163,7 @@ class TestCreateLLMMiniMax:
         env = {
             "LLM_PROVIDER": "minimax",
             "MINIMAX_API_KEY": "test-key-abc",
-            "LLM_MODEL": "MiniMax-M2.5",
+            "LLM_MODEL": "MiniMax-M2.7",
         }
         with patch.dict(os.environ, env, clear=False):
             with patch.dict("sys.modules", {"langchain_openai": mock_module}):
@@ -172,7 +172,7 @@ class TestCreateLLMMiniMax:
                 reload(mod)
                 mod.create_llm()
                 call_kwargs = mock_cls.call_args[1]
-                assert call_kwargs["model"] == "MiniMax-M2.5"
+                assert call_kwargs["model"] == "MiniMax-M2.7"
         os.environ.pop("LLM_MODEL", None)
 
 
@@ -197,7 +197,7 @@ class TestDefaultModels:
 
     def test_minimax_default(self):
         from tools.llm_provider import _DEFAULT_MODELS
-        assert _DEFAULT_MODELS["minimax"] == "MiniMax-M2.7"
+        assert _DEFAULT_MODELS["minimax"] == "MiniMax-M3"
 
 
 class TestChatModuleIntegration:

--- a/tools/llm_provider.py
+++ b/tools/llm_provider.py
@@ -27,7 +27,7 @@ if dotenv_path.exists():
 # Provider → default model mapping
 _DEFAULT_MODELS = {
     "groq": "deepseek-r1-distill-llama-70b",
-    "minimax": "MiniMax-M2.7",
+    "minimax": "MiniMax-M3",
 }
 
 # MiniMax requires temperature in (0.0, 1.0]


### PR DESCRIPTION
## Summary

Upgrades the default MiniMax model from `MiniMax-M2.7` to `MiniMax-M3`. M3 is the current flagship MiniMax model with a 512K context window (vs. 204K on M2.7), making it a stronger default for DeepGit's deep-research workflows over large repositories.

## Changes

- `tools/llm_provider.py` — `_DEFAULT_MODELS["minimax"]` updated to `MiniMax-M3`
- `tests/test_llm_provider.py` — corresponding default-model assertions updated; `test_env_model_override` retargeted to `MiniMax-M2.7` (still a supported model). `MiniMax-M2.7-highspeed` integration tests unchanged.
- `README.md` — provider table now lists `MiniMax-M3` (512K context) as the default; the `LLM_MODEL` override comment uses M3.

## Backward compatibility

`M2.7` and `M2.7-highspeed` continue to work — users can pin via `LLM_MODEL=MiniMax-M2.7` (or `M2.7-highspeed` for low-latency). Only the **default** changes. No API URL or env-var changes.

## Test Plan

- [x] `pytest tests/test_llm_provider.py` → 22 passed, 3 integration skipped (no API key in CI)
- [x] Local invocation against `https://api.minimax.io/v1` with `model=MiniMax-M3` reaches the API and is accepted by the endpoint (no model-not-found errors)